### PR TITLE
Fix static styles href and cdn links

### DIFF
--- a/demo/movie_svc/templates/shared/_layout.html
+++ b/demo/movie_svc/templates/shared/_layout.html
@@ -10,11 +10,11 @@
     <title>MovieDB Service</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="//oss.maxcdn.com/libs/twitter-bootstrap/3.0.3/css/bootstrap.min.css" rel="stylesheet">
+    <link href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.3/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Custom styles for this scaffold -->
-    <link href="/css/theme.css" rel="stylesheet">
-    <link href="/css/docs.css" rel="stylesheet">
+    <link href="/static/css/theme.css" rel="stylesheet">
+    <link href="/static/css/docs.css" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -58,7 +58,7 @@
 <!-- Bootstrap core JavaScript
 ================================================== -->
 <!-- Placed at the end of the document so the pages load faster -->
-<script src="//oss.maxcdn.com/libs/jquery/1.10.2/jquery.min.js"></script>
-<script src="//oss.maxcdn.com/libs/twitter-bootstrap/3.0.3/js/bootstrap.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.3/js/bootstrap.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
about local style assets, in my experience the custom style links should be prefixed with '/static/' to work properly.
Also the old cdn urls seems not working, result with the following message:
Fastly error: unknown domain: origin2.jsdelivr.net. Please check that this domain has been added to a service.
Details: cache-cdg20782-CDG

so, I've replaced them with the ones hosted in cloudflare.